### PR TITLE
Add fallback to ISO 8601 date format in `ContentDispositionParser`.

### DIFF
--- a/lib/mechanize/http/content_disposition_parser.rb
+++ b/lib/mechanize/http/content_disposition_parser.rb
@@ -16,6 +16,7 @@ end
 # * Missing disposition-type
 # * Multiple semicolons
 # * Whitespace around semicolons
+# * Dates in ISO 8601 format
 
 class Mechanize::HTTP::ContentDispositionParser
 
@@ -93,7 +94,17 @@ class Mechanize::HTTP::ContentDispositionParser
               when /^filename$/ then
                 rfc_2045_value
               when /^(creation|modification|read)-date$/ then
-                Time.rfc822 rfc_2045_quoted_string
+                date = rfc_2045_quoted_string
+
+                begin
+                  Time.rfc822 date
+                rescue ArgumentError
+                  begin
+                    Time.iso8601 date
+                  rescue ArgumentError
+                    nil
+                  end
+                end
               when /^size$/ then
                 rfc_2045_value.to_i(10)
               else


### PR DESCRIPTION
Some websites incorrectly use ISO 8601 for the dates, causing an exception to be raised and rendering all other correctly specified fields unusable.